### PR TITLE
keep synonymous variants

### DIFF
--- a/src/main/java/de/charite/compbio/pediasimulator/cmd/JsonWithVCFExtenderCommand.java
+++ b/src/main/java/de/charite/compbio/pediasimulator/cmd/JsonWithVCFExtenderCommand.java
@@ -71,7 +71,7 @@ public class JsonWithVCFExtenderCommand implements ICommand {
 				.add(new LessOrEqualInfoFieldFilter("EAS_AF", 0.01)).add(new LessOrEqualInfoFieldFilter("EUR_AF", 0.01))
 				.add(new LessOrEqualInfoFieldFilter("SAS_AF", 0.01))
 				.add(new LessOrEqualInfoFieldFilter("1KG_BEST_AF", 0.01))
-				.add(new JannovarEffectInfoFilter(VariantEffect._SMALLEST_MODERATE_IMPACT))
+				.add(new JannovarEffectInfoFilter(VariantEffect.SYNONYMOUS_VARIANT))
 				.add(new JannovarGeneInfoFilter(genes)).build();
 
 		// 1.4 ini sampler


### PR DESCRIPTION
there are pathogenic synonymous variants that we currently miss :(.
We shouldn't filter them out. Either adjust the ordinal if there is a lower one that just contains synonymous variants in addition, or add an exception for synonymous variants. Code hasn't been tested.